### PR TITLE
Fix: WARN  Issues with peer dependencies found

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+overrides=@mui/material@^5.0.0:
+  dependencies:
+    @mui/material: replaced-by=@mui/joy

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.11",
     "@mui/joy": "^5.0.0-alpha.71",
+    "@mui/material": "^5.0.0",
     "eventsource-parser": "^0.1.0",
     "next": "^13.2.4",
     "prismjs": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.11",
     "@mui/joy": "^5.0.0-alpha.71",
-    "@mui/material": "^5.0.0",
     "eventsource-parser": "^0.1.0",
     "next": "^13.2.4",
     "prismjs": "^1.29.0",


### PR DESCRIPTION
```
.
├─┬ @mui/icons-material 5.11.11
│ └── ✕ missing peer @mui/material@^5.0.0
└─┬ @codesandbox/sandpack-react 2.1.11
  └─┬ ansi-to-react 6.1.6
    ├── ✕ unmet peer react@"^16.3.2 || ^17.0.0": found 18.2.0
    └── ✕ unmet peer react-dom@"^16.3.2 || ^17.0.0": found 18.2.0
Peer dependencies that should be installed:
  @mui/material@^5.0.0
```