### PR TITLE
disable ligatures inside code blocks

### DIFF
--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -381,7 +381,7 @@ export function ChatMessage(props: { message: DMessage, disableSend: boolean, on
 
           {parseBlocks(fromSystem, collapsedText).map((block, index) =>
             block.type === 'code'
-              ? <RenderCode key={'code-' + index} codeBlock={block} theme={theme} sx={chatFontCss} />
+              ? <RenderCode key={'code-' + index} codeBlock={block} theme={theme} sx={{ ...chatFontCss, fontVariantLigatures: 'none'}} />
               : <RenderText key={'text-' + index} textBlock={block} onDoubleClick={handleMenuEdit} sx={textBackground ? { ...chatFontCss, background: textBackground } : chatFontCss} />,
           )}
 


### PR DESCRIPTION
https://github.com/enricoros/nextjs-chatgpt-app/issues/33

don't render `!=`, `==`, etc as ligatured glyphs

<img width="1469" alt="screenshot-2023-03-30 14-13-00" src="https://user-images.githubusercontent.com/51766/228965887-c476b46a-227a-4cb0-b1b7-244a04df4193.png">
