### PR TITLE
Made the default height of the input box 2 instead of 5

### DIFF
--- a/components/Composer.tsx
+++ b/components/Composer.tsx
@@ -222,7 +222,7 @@ export function Composer(props: { disableSend: boolean; isDeveloperMode: boolean
 
           <Textarea
             variant='soft' autoFocus placeholder={textPlaceholder}
-            minRows={5} maxRows={12}
+            minRows={2} maxRows={12}
             onKeyDown={handleKeyPress}
             onDragEnter={handleMessageDragEnter}
             value={composeText} onChange={(e) => setComposeText(e.target.value)}


### PR DESCRIPTION
I made this since the input box took up so much space on a small mobile screen, hard to see the output