### PR TITLE
display SystemPurpose symbols in appbar and avatars

### DIFF
--- a/components/ApplicationBar.tsx
+++ b/components/ApplicationBar.tsx
@@ -17,6 +17,7 @@ import { ChatModelId, ChatModels, SystemPurposeId, SystemPurposes } from '@/lib/
 import { ConfirmationModal } from '@/components/dialogs/ConfirmationModal';
 import { PagesMenu } from '@/components/Pages';
 import { StyledDropdown } from '@/components/util/StyledDropdown';
+import { StyledDropdownWithSymbol } from '@/components/util/StyledDropdownWithSymbol';
 import { useChatStore } from '@/lib/store-chats';
 import { useSettingsStore } from '@/lib/store-settings';
 
@@ -125,7 +126,7 @@ export function ApplicationBar(props: {
 
         {chatModelId && <StyledDropdown items={ChatModels} value={chatModelId} onChange={handleChatModelChange} />}
 
-        {systemPurposeId && <StyledDropdown items={SystemPurposes} value={systemPurposeId} onChange={handleSystemPurposeChange} />}
+        {systemPurposeId && <StyledDropdownWithSymbol items={SystemPurposes} value={systemPurposeId} onChange={handleSystemPurposeChange} />}
 
       </Stack>
 

--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -29,6 +29,7 @@ import { Link } from '@/components/util/Link';
 import { cssRainbowColorKeyframes } from '@/lib/theme';
 import { prettyBaseModel } from '@/lib/publish';
 import { useSettingsStore } from '@/lib/store-settings';
+import { SystemPurposeId, SystemPurposes } from '@/lib/data';
 
 
 /// Utilities to parse messages into blocks of text and code
@@ -244,7 +245,7 @@ export function ChatMessage(props: { message: DMessage, isLast: boolean, onMessa
     avatar: messageAvatar,
     typing: messageTyping,
     role: messageRole,
-    // purposeId: messagePurposeId,
+    purposeId: messagePurposeId,
     originLLM: messageModelId,
     // tokenCount: messageTokenCount,
     updated: messageUpdated,
@@ -353,12 +354,25 @@ export function ChatMessage(props: { message: DMessage, isLast: boolean, onMessa
                 borderRadius: 8,
               }}
             />;
+          const symbol = SystemPurposes[messagePurposeId as SystemPurposeId]?.symbol;
+          if (symbol) 
+            return <Box 
+              sx={{
+                fontSize: '24px',
+                textAlign: 'center',
+                width: '100%',
+                height: 40,
+                lineHeight: '40px',
+              }}
+            >
+              {symbol}
+            </Box>
           return <SmartToyOutlinedIcon sx={{ width: 40, height: 40 }} />; // https://mui.com/static/images/avatar/2.jpg
         case 'user':
           return <Face6Icon sx={{ width: 40, height: 40 }} />;            // https://www.svgrepo.com/show/306500/openai.svg
       }
       return <Avatar alt={messageSender} />;
-    }, [messageAvatar, messageRole, messageSender, messageTyping, showAvatars],
+    }, [messageAvatar, messageRole, messagePurposeId, messageSender, messageTyping, showAvatars],
   );
 
   // text box css

--- a/components/util/StyledDropdownWithSymbol.tsx
+++ b/components/util/StyledDropdownWithSymbol.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import { StyledDropdown } from './StyledDropdown';
+import { SxProps } from '@mui/joy/styles/types';
+
+
+/**
+ * Wrapper for StyledDropdown that adds a symbol in front of the title
+ */
+type Props<TValue extends string> = {
+  value: TValue;
+  items: Record<string, { title: string, symbol: string }>;
+  onChange: (event: any, value: TValue | null) => void;
+  sx?: SxProps;
+};
+
+export const StyledDropdownWithSymbol = <TValue extends string>({ value, items, onChange, sx }: Props<TValue>) => {
+  const itemsWithSymbol = Object.keys(items).map((key: string) => ({
+    key,
+    value: items[key].symbol + ' ' + items[key].title
+  }));
+
+  return (
+    <StyledDropdown
+      value={value}
+      items={Object.fromEntries(itemsWithSymbol.map(({ key, value }) => [key, { title: value }]))}
+      onChange={onChange}
+      sx={sx}
+    />
+  );
+};

--- a/components/util/StyledDropdownWithSymbol.tsx
+++ b/components/util/StyledDropdownWithSymbol.tsx
@@ -17,7 +17,7 @@ type Props<TValue extends string> = {
 export const StyledDropdownWithSymbol = <TValue extends string>({ value, items, onChange, sx }: Props<TValue>) => {
   const itemsWithSymbol = Object.keys(items).map((key: string) => ({
     key,
-    value: items[key].symbol + ' ' + items[key].title
+    value: (!!items[key].symbol ? items[key].symbol + ' ' : '') + items[key].title
   }));
 
   return (


### PR DESCRIPTION
This PR displays SystemPurpose symbols in two places:
- ChatMessage avatars. 
  - Renders original robot icon if no symbol present, no change to menus or typing avatar.
- ApplicationBar dropdown menu, using a new StyledDropdownWithSymbol component
  - I wanted to avoid expanding StyledDropdownWithSymbol, but could see folding this change into it rather than using a wrapper.
  - Considered but didn't implement rendering only the symbol on narrow screens to avoid viewport overflow issues with long SystemPurpose labels

<img width="1103" alt="Screen Shot 2023-04-10 at 3 35 59 PM" src="https://user-images.githubusercontent.com/51766/231012677-552d93da-c324-4d80-869f-d4357c16a21a.png">
