### PR TITLE
toggle api key

### DIFF
--- a/components/dialogs/SettingsModal.tsx
+++ b/components/dialogs/SettingsModal.tsx
@@ -263,7 +263,7 @@ export function SettingsModal({ open, onClose }: { open: boolean, onClose: () =>
 
         <Box sx={{ mt: 4, display: 'flex', justifyContent: 'flex-end' }}>
           <Button variant='solid' color={isValidKey ? 'primary' : 'neutral'} onClick={onClose}>
-            Close
+            Save
           </Button>
         </Box>
 

--- a/components/dialogs/SettingsModal.tsx
+++ b/components/dialogs/SettingsModal.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { Box, Button, FormControl, FormHelperText, FormLabel, IconButton, Input, Modal, ModalClose, ModalDialog, ModalOverflow, Radio, RadioGroup, Slider, Stack, Switch, Typography } from '@mui/joy';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+
 import KeyIcon from '@mui/icons-material/Key';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
@@ -69,11 +72,17 @@ export function SettingsModal({ open, onClose }: { open: boolean, onClose: () =>
     setModelMaxResponseTokens,
   } = useSettingsStore(state => state, shallow);
 
+  const [showApiKeyValue, setShowApiKeyValue] = React.useState(false);
+
   const handleCenterModeChange = (event: React.ChangeEvent<HTMLInputElement>) => setCenterMode(event.target.value as 'narrow' | 'wide' | 'full' || 'wide');
 
   const handleRenderMarkdownChange = (event: React.ChangeEvent<HTMLInputElement>) => setRenderMarkdown(event.target.checked);
 
   const handleShowSearchBarChange = (event: React.ChangeEvent<HTMLInputElement>) => setShowPurposeFinder(event.target.checked);
+
+  const handleToggleApiKeyValue = () => {
+    setShowApiKeyValue(!showApiKeyValue);
+  };
 
   const handleZenModeChange = (event: React.ChangeEvent<HTMLInputElement>) => setZenMode(event.target.value as 'clean' | 'cleaner');
 
@@ -109,9 +118,15 @@ export function SettingsModal({ open, onClose }: { open: boolean, onClose: () =>
               OpenAI API Key {needsApiKey ? '' : '(optional)'}
             </FormLabel>
             <Input
-              variant='outlined' type='password' placeholder={needsApiKey ? 'required' : 'sk-...'} error={needsApiKey && !isValidKey}
+              variant='outlined' type={showApiKeyValue ? 'text' : 'password'} placeholder={needsApiKey ? 'required' : 'sk-...'} error={needsApiKey && !isValidKey}
               value={apiKey} onChange={handleApiKeyChange} onKeyDown={handleApiKeyDown}
               startDecorator={<KeyIcon />}
+              endDecorator={!!apiKey && (
+                <IconButton variant='plain' color='neutral' onClick={handleToggleApiKeyValue}>
+                  {showApiKeyValue ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                </IconButton>
+              )}
+
             />
             <FormHelperText sx={{ display: 'block', lineHeight: 1.75 }}>
               {needsApiKey


### PR DESCRIPTION
2 changes:

- toggle visibility of API key value using with `Input endDecorator={eyeball icon button}`. I shuffle a few keys associated with different accounts so it's useful to spot check this. The decorator is only shown while the input has a value.
  - I have not tested how this works with API key as env variable - just local storage
- change label of Settings `Close` button to `Save`, as its effective function is similar to a submit button

![localhost_3000_](https://user-images.githubusercontent.com/51766/231594734-28c50f1e-04cf-4cb0-a92d-e99a1297a2a7.png)