### PR TITLE
Enabled stream option for Text decoding

### DIFF
--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -51,7 +51,7 @@ export async function streamAssistantMessage(
 
         if (done) break;
 
-        incrementalText += decoder.decode(value);
+        incrementalText += decoder.decode(value, {stream: true});
 
         // there may be a JSON object at the beginning of the message, which contains the model name (streaming workaround)
         if (!parsedFirstPacket && incrementalText.startsWith('{')) {

--- a/pages/api/openai/stream-chat.ts
+++ b/pages/api/openai/stream-chat.ts
@@ -79,7 +79,7 @@ async function chatStreamRepeater(input: ApiChatInput, signal: AbortSignal): Pro
     // https://web.dev/streams/#asynchronous-iteration
     const decoder = new TextDecoder();
     for await (const upstreamChunk of upstreamResponse.body as any)
-      upstreamParser.feed(decoder.decode(upstreamChunk));
+      upstreamParser.feed(decoder.decode(upstreamChunk, {stream: true}));
 
   };
 


### PR DESCRIPTION
A quick bug fix.

https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode

Added `stream `option to TextDecoder.decode in order to prevent malformed multi-byte characters like on in below. (Happens more often when deployed to vercel than running it on local)
 
![スクリーンショット 2023-04-13 9 44 58 (3)](https://user-images.githubusercontent.com/5536168/231623931-ac272b20-4c15-4cd7-8629-1a161f7df095.jpg)
